### PR TITLE
force the base64 blobs to be strings in the XML, not arrays of bytes

### DIFF
--- a/suds_passworddigest/token.py
+++ b/suds_passworddigest/token.py
@@ -54,7 +54,7 @@ class UsernameDigestToken(UsernameToken):
 		root.append(u)
 
 		p = Element('Password', ns=wssens)
-		p.setText(self.generate_digest())
+		p.setText(self.generate_digest().decode('ascii'))
 		p.set(wspassd[0], wspassd[1])
 		root.append(p)
 
@@ -63,7 +63,7 @@ class UsernameDigestToken(UsernameToken):
 		if not isinstance(self.nonce, bytes) :
 			nonce_bytes = self.nonce.encode('utf-8')
 
-		n.setText(base64.encodebytes(nonce_bytes)[:-1])
+		n.setText((base64.encodebytes(nonce_bytes)[:-1]).decode('ascii'))
 		n.set(wsenctype[0], wsenctype[1])
 		root.append(n)
 


### PR DESCRIPTION
When they are array of bytes, we end up with `b'` prefix and `'` suffix within the XML itself

         <wsse:UsernameToken>
            <wsse:Username>Link</wsse:Username>
            <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">
		b&apos;0OZLAyOpyT0A/PSKpin6QcKsRBQ=&apos;</wsse:Password>
            <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">
		b&apos;ZmJlYjlkY2U0MGI2ZGRmZjY3YjFlMTUyNWE0MzcyYWY=&apos;</wsse:Nonce>
            <wsu:Created>2019-03-14T08:04:56.970017+00:00</wsu:Created>
         </wsse:UsernameToken>

This makes the token invalid at the receiver (at least if the receiver isn't using python3)